### PR TITLE
feat(path): access queries via path (#80 and #83)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ class App extends Component {
         <Router>
           <div>
             <Route path="/" exact={true} component={QueryEditorScreen} />
+            <Route path="/query/:namespace/:queryName/:revision?" component={QueryEditorScreen}/>
             <Route path="/resources-editor" exact={true} component={ResourcesEditorScreen} />
           </div>
         </Router>

--- a/src/actions/queryActionCreator.js
+++ b/src/actions/queryActionCreator.js
@@ -5,6 +5,7 @@
 
 // Redux actions
 import { QUERY_ACTIONS } from "../reducers/queryReducer";
+import { SIDEBAR_ACTIONS } from "../reducers/sidebarReducer"
 
 // API Calls and processing dependencies
 import {
@@ -22,7 +23,11 @@ const store = require("../store/storeConfig").store;
 // UI State manipulation
 export function handleNewQuery() {
   store.dispatch({
-    type: QUERY_ACTIONS.INITIAL_STATE
+    type: QUERY_ACTIONS.INITIAL_STATE,
+  });
+
+  store.dispatch({
+    type: SIDEBAR_ACTIONS.INITIAL_STATE,
   });
 
   handleLoadNamespaces();
@@ -182,14 +187,22 @@ export function handleLoadRevisions() {
   });
 }
 
-export function handleLoadQueryRevision(evt) {
-  const dispatch = store.dispatch;
+export const handleRedirectToQuery = navigation => evt => {  
+  const revision = evt.target.value
 
   const { namespace, queryName } = store.getState().queryReducer;
 
+  let path = `/query/${namespace}/${queryName}/${revision}`
+
+  return navigation.push(path)
+}
+
+export function handleLoadQueryFromURL({ namespace, queryName, revision }) {
+  const dispatch = store.dispatch;
+
   dispatch({ type: QUERY_ACTIONS.QUERY_LOADING });
 
-  loadRevision(namespace, queryName, evt.target.value, (response, error) => {
+  loadRevision(namespace, queryName, revision, (response, error) => {
     if (error) {
       dispatch({
         type: QUERY_ACTIONS.QUERY_ERROR,
@@ -198,9 +211,12 @@ export function handleLoadQueryRevision(evt) {
     } else {
       dispatch({
         type: QUERY_ACTIONS.QUERY_LOADED,
+        namespace: namespace,
         queryName: queryName,
+        revision: revision,
         value: response
       });
+      dispatch({ type: QUERY_ACTIONS.LOAD_REVISIONS })
     }
   });
 }

--- a/src/actions/queryActionCreator.js
+++ b/src/actions/queryActionCreator.js
@@ -160,7 +160,7 @@ export function handleLoadNamespaces() {
       dispatch({ type: QUERY_ACTIONS.NAMESPACES_LOADED, value: [] });
       alert("Error loading namespaces: " + error);
     } else {
-      dispatch({ type: QUERY_ACTIONS.NAMESPACES_LOADED, value: response });
+      dispatch({ type: QUERY_ACTIONS.NAMESPACES_LOADED, value: response.sort(function (a, b) { return a._id.toLowerCase().localeCompare(b._id.toLowerCase()) })});
     }
   });
 }

--- a/src/actions/sidebarActionCreator.js
+++ b/src/actions/sidebarActionCreator.js
@@ -1,0 +1,55 @@
+
+// Redux actions
+import { SIDEBAR_ACTIONS } from "../reducers/sidebarReducer";
+import { loadQueries, loadRevisionByUrl } from "../api/restQLAPI";
+
+const store = require("../store/storeConfig").store;
+
+export function handleSidebarLoadQueries(namespace) {
+    const dispatch = store.dispatch;
+  
+    dispatch({
+      type: SIDEBAR_ACTIONS.QUERIES_LOADING,
+      value: namespace
+    });
+  
+    loadQueries(namespace, (response, error) => {
+      if (error) {
+        dispatch({ type: SIDEBAR_ACTIONS.QUERIES_LOADED, value: [] });
+        alert("Error loading queries: " + error);
+      } else {
+        dispatch({
+          type: SIDEBAR_ACTIONS.QUERIES_LOADED,
+          value: response.queries
+        });
+      }
+    });
+  }
+
+export function handleSidebarLoadQuery(query) {
+  const dispatch = store.dispatch;
+
+  dispatch({
+    type: SIDEBAR_ACTIONS.QUERY_LOADING
+  });
+
+  loadRevisionByUrl(query["last-revision"], (response, error) => {
+    if (error) {
+      dispatch({
+        type: SIDEBAR_ACTIONS.QUERY_ERROR,
+        value: error
+      });
+    } else {
+      dispatch({
+        type: SIDEBAR_ACTIONS.QUERY_LOADED,
+        queryName: query.id,
+        value: response
+      });
+
+      dispatch({
+        type: SIDEBAR_ACTIONS.LOAD_REVISIONS
+      });
+    }
+  });
+}
+  

--- a/src/components/query/QueryEditor.js
+++ b/src/components/query/QueryEditor.js
@@ -81,7 +81,8 @@ export default class QueryEditor extends Component {
               <RevisionCombo
                 toggle={this.props.revisions.length > 0}
                 revisions={this.props.revisions}
-                handleLoadQueryRevision={this.props.handleLoadQueryRevision}
+                onChange={this.props.handleRedirectToQuery(this.props.history)}
+                revisionNumber={this.props.revisionNumber}
               />
             )}
           </div>

--- a/src/components/query/QueryEditorScreen.js
+++ b/src/components/query/QueryEditorScreen.js
@@ -43,7 +43,7 @@ import QuerySidebar from "./QuerySidebar";
 import QueryEditor from "./QueryEditor";
 
 function shouldUpdate(prevProps, nextProps) {
-  return (prevProps.namespace !== nextProps.namespace || prevProps.queryName !== nextProps.queryName || prevProps.revisionNumber !== nextProps.revision) && (nextProps.queryName !== undefined)
+  return (prevProps.namespace !== nextProps.namespace || prevProps.queryName !== nextProps.queryName || prevProps.revisionNumber !== nextProps.revision)
 }
 
 class QueryEditorScreen extends Component {

--- a/src/components/query/QueryNavbar.js
+++ b/src/components/query/QueryNavbar.js
@@ -10,7 +10,7 @@ export default class QueryNavbar extends Component {
       <Navbar>
         <Navbar.Header>
           <Navbar.Brand>
-            <Link to={"/"}>
+            <Link to={"/"} onClick={this.props.newQuery}>
               <ReactSVG src={this.props.logo} alt="Logo" />
             </Link>
           </Navbar.Brand>
@@ -22,9 +22,11 @@ export default class QueryNavbar extends Component {
               <Button bsStyle="default" onClick={this.props.toggleSidebar}>
                 Queries
               </Button>
-              <Button bsStyle="danger" onClick={this.props.newQuery}>
-                New Query
-              </Button>
+              <Link to={"/"}>
+                <Button bsStyle="danger" onClick={this.props.newQuery}>
+                  New Query
+                </Button>
+              </Link>
             </FormGroup>
           </Navbar.Form>
         </Navbar.Collapse>

--- a/src/components/query/QuerySidebar.js
+++ b/src/components/query/QuerySidebar.js
@@ -56,10 +56,7 @@ export default class QuerySidebar extends Component {
 
   renderNamespaces = () => {
     if (!this.props.loadingNamespaces) {
-      let sortedNamespaces = this.props.namespaces.sort(function (a, b) {
-        return a._id.toLowerCase().localeCompare(b._id.toLowerCase());
-      })
-      let namespaces = sortedNamespaces.map((val, index) => {
+      let namespaces = this.props.namespaces.map((val, index) => {
         if (val._id !== null && val._id.trim() !== '')
           return (
             <li key={index}>

--- a/src/components/query/QuerySidebar.js
+++ b/src/components/query/QuerySidebar.js
@@ -56,7 +56,10 @@ export default class QuerySidebar extends Component {
 
   renderNamespaces = () => {
     if (!this.props.loadingNamespaces) {
-      let namespaces = this.props.namespaces.map((val, index) => {
+      let sortedNamespaces = this.props.namespaces.sort(function (a, b) {
+        return a._id.toLowerCase().localeCompare(b._id.toLowerCase());
+      })
+      let namespaces = sortedNamespaces.map((val, index) => {
         if (val._id !== null && val._id.trim() !== '')
           return (
             <li key={index}>

--- a/src/components/query/RevisionCombo.js
+++ b/src/components/query/RevisionCombo.js
@@ -23,9 +23,8 @@ export default class RevisionCombo extends Component {
   render() {
     if (this.props.toggle) {
       const options = this.renderOptions();
-
       return (
-        <select className="revisionPicker" onChange={this.props.handleLoadQueryRevision}>
+        <select className="revisionPicker" onChange={this.props.onChange} value={this.props.revisionNumber}>
           {options}
         </select>
       );

--- a/src/components/query/SidebarQueries.js
+++ b/src/components/query/SidebarQueries.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import { Collapse } from 'react-bootstrap';
 
+import { Link } from "react-router-dom";
 
 export default class SidebarQueries extends Component {
 
@@ -10,7 +11,7 @@ export default class SidebarQueries extends Component {
       return this.props.queries.map((val, index) => {
         return (
           <li key={index}>
-            <a onClick={this.props.loadQuery.bind(this, val)}>{val.id}</a>
+            <Link to={`/query/${this.props.namespace}/${val.id}`} >{val.id}</Link>
           </li>
         );
       });
@@ -22,7 +23,6 @@ export default class SidebarQueries extends Component {
 
   render() {
     const shouldCollapse = this.props.namespace === this.props.collapsedNamespace && !this.props.loadingQueries;
-
     return (
       <ul className="queries">
         <Collapse in={shouldCollapse}>

--- a/src/components/resources/ResourcesEditorScreen.js
+++ b/src/components/resources/ResourcesEditorScreen.js
@@ -27,6 +27,7 @@ import Logo from "../restQL-logo.svg";
 import ResourcesNavbar from "./ResourcesNavbar";
 import ResourcesMenu from "./ResourcesMenu";
 import ResourcesEditor from "./ResourcesEditor";
+import { handleNewQuery } from "../../actions/queryActionCreator";
 
 class ResourcesEditorScreen extends Component {
   constructor(props) {
@@ -41,7 +42,7 @@ class ResourcesEditorScreen extends Component {
   render() {
     return (
       <div>
-        <ResourcesNavbar logo={Logo} queryEditorLink={""} />
+        <ResourcesNavbar logo={Logo} queryEditorLink={""} newQuery={handleNewQuery} />
 
         <Row>
           <Col xs={4} md={2}>

--- a/src/components/resources/ResourcesNavbar.js
+++ b/src/components/resources/ResourcesNavbar.js
@@ -10,7 +10,7 @@ export default class ResourcesNavbar extends Component {
       <Navbar>
         <Navbar.Header>
           <Navbar.Brand>
-            <Link to={"/"}>
+            <Link to={"/"} onClick={this.props.newQuery}>
               <ReactSVG src={this.props.logo} alt="Logo" />
             </Link>
           </Navbar.Brand>
@@ -21,6 +21,7 @@ export default class ResourcesNavbar extends Component {
             <FormGroup controlId="formInlineName">
               <Link
                 to={this.props.queryEditorLink}
+                onClick={this.props.newQuery}
                 className="btn btn-md btn-info"
               >
                 Query Editor

--- a/src/reducers/queryReducer.js
+++ b/src/reducers/queryReducer.js
@@ -1,7 +1,7 @@
 // Initial state
 export const initialState = {
-  namespace: "",
-  queryName: "",
+  namespace: undefined,
+  queryName: undefined,
   query: "",
   queryParams: "",
   running: false,
@@ -16,7 +16,7 @@ export const initialState = {
   queries: [],
   revisions: [],
 
-  revisionNumber: null,
+  revisionNumber: undefined,
   
 
   shouldLoadRevisions: false

--- a/src/reducers/queryReducer.js
+++ b/src/reducers/queryReducer.js
@@ -16,6 +16,9 @@ export const initialState = {
   queries: [],
   revisions: [],
 
+  revisionNumber: null,
+  
+
   shouldLoadRevisions: false
 };
 
@@ -47,7 +50,8 @@ export const QUERY_ACTIONS = {
 
   REVISIONS_LOADING: "REVISIONS_LOADING",
   REVISIONS_LOADED: "REVISIONS_LOADED",
-  LOAD_REVISIONS: "LOAD_REVISIONS"
+  LOAD_REVISIONS: "LOAD_REVISIONS",
+  LOAD_URL_QUERY: "LOAD_URL_QUERY"
 };
 
 const queryReducer = (state = initialState, action) => {
@@ -114,22 +118,31 @@ const queryReducer = (state = initialState, action) => {
     case QUERY_ACTIONS.QUERY_LOADED:
       return {
         ...state,
+        namespace: action.namespace,
         queryName: action.queryName,
+        revision: action.revision,
         query: action.value,
         running: false,
         showSidebar: false
       };
+    case QUERY_ACTIONS.LOAD_URL_QUERY:
+      return { 
+        ...state, 
+        shouldLoadRevisions: true,
+        namespace: action.namespace,
+        queryName: action.queryName,
+        revision: action.revision
+      };
 
     case QUERY_ACTIONS.LOAD_REVISIONS:
       return { ...state, shouldLoadRevisions: true };
-
     case QUERY_ACTIONS.REVISIONS_LOADING:
       return {
         ...state,
         running: true,
         shouldLoadRevisions: false,
         revisions: []
-      };
+        };
     case QUERY_ACTIONS.REVISIONS_LOADED:
       return { ...state, running: false, revisions: action.value };
     case QUERY_ACTIONS.INITIAL_STATE:

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -2,10 +2,12 @@ import { combineReducers } from "redux";
 
 import queryReducer from "./queryReducer";
 import environmentReducer from "./environmentReducer";
+import sidebarReducer from "./sidebarReducer";
 
 const rootReducer = combineReducers({
   environmentReducer,
-  queryReducer
+  queryReducer,
+  sidebarReducer
 });
 
 export default rootReducer;

--- a/src/reducers/sidebarReducer.js
+++ b/src/reducers/sidebarReducer.js
@@ -1,7 +1,7 @@
 export const initialState = {
-    namespace: "",
-    queryName: "",
-    revision: null,
+    namespace: undefined,
+    queryName: undefined,
+    revision: undefined,
   };
 
 export const SIDEBAR_ACTIONS = {

--- a/src/reducers/sidebarReducer.js
+++ b/src/reducers/sidebarReducer.js
@@ -1,0 +1,48 @@
+export const initialState = {
+    namespace: "",
+    queryName: "",
+    revision: null,
+  };
+
+export const SIDEBAR_ACTIONS = {
+  INITIAL_STATE: "SIDEBAR_INITIAL_STATE",
+
+  QUERIES_LOADING: "SIDEBAR_QUERIES_LOADING",
+  QUERIES_LOADED: "SIDEBAR_QUERIES_LOADED",
+  QUERY_LOADING: "SIDEBAR_QUERY_LOADING",
+  QUERY_LOADED: "SIDEBAR_QUERY_LOADED"
+
+  };
+
+  const sidebarReducer = (state = initialState, action) => {
+    switch (action.type) {
+      case SIDEBAR_ACTIONS.QUERIES_LOADING:
+        return {
+          ...initialState,
+          loadingQueries: true,
+          namespace: action.value
+        };
+      case SIDEBAR_ACTIONS.QUERIES_LOADED:
+        return { ...state, loadingQueries: false, queries: action.value };
+      case SIDEBAR_ACTIONS.QUERY_LOADING:
+        return { ...state, query: "", queryResult: "", running: true };
+      case SIDEBAR_ACTIONS.QUERY_LOADED:
+        return {
+            ...state,
+            namespace: action.namespace,
+            queryName: action.queryName,
+            revision: action.revision,
+            query: action.value,
+            running: false,
+            showSidebar: false
+        };
+
+      case SIDEBAR_ACTIONS.INITIAL_STATE:
+        return initialState;
+  
+      default:
+        return state;
+    }
+}
+
+export default sidebarReducer;

--- a/src/server/persistence/index.js
+++ b/src/server/persistence/index.js
@@ -142,7 +142,7 @@ function loadQueries(namespace) {
         namespace: namespace
       },
       [],
-      { sort: { name: 1 } }
+      {}
     )
     .then(queries => {
       return Array.from(queries, buildQuery);


### PR DESCRIPTION
Major changes with some refactoring. The changes in this pull request solves issues B2W-BIT/restQL-http/issues/80 and https://github.com/B2W-BIT/restQL-http/issues/83 

CHANGELOG:
* Made restQL logo clickable both in Query Editor Screen and Resources Editor Screen;
* Ordered sidebar resources and queries;
* Separated the Sidebar state from Query Editor Screen state (REDUX). This fixes the bug where clicking another resource at the sidebar changes the resource name displayed at the Query Editor Screen;
* Made possible to access a query via path, as in `/query/heroes/super-powered-heroes/3`

The query path works as the following:
`/query/namespace/queryName/revisionNumber`

* **namespace** - The name of the resource (i.e: `villains`)
* **queryName** - The name of the query (i.e: `villains-with-capes`)
* **revisionNumber** - The number of the revision, if any (i.e: `3`)

If revision number is not in path, RestQL Manager will load the latest revision